### PR TITLE
LTB-79 | core: Accept job description for ScrapeJob request as a parameter along with URL

### DIFF
--- a/api/proto/letraz/v1/letraz-utils.pb.go
+++ b/api/proto/letraz/v1/letraz-utils.pb.go
@@ -24,8 +24,9 @@ const (
 
 type ScrapeJobRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
-	Options       *ScrapeOptions         `protobuf:"bytes,2,opt,name=options,proto3" json:"options,omitempty"`
+	Url           *string                `protobuf:"bytes,1,opt,name=url,proto3,oneof" json:"url,omitempty"`
+	Description   *string                `protobuf:"bytes,2,opt,name=description,proto3,oneof" json:"description,omitempty"`
+	Options       *ScrapeOptions         `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -61,8 +62,15 @@ func (*ScrapeJobRequest) Descriptor() ([]byte, []int) {
 }
 
 func (x *ScrapeJobRequest) GetUrl() string {
-	if x != nil {
-		return x.Url
+	if x != nil && x.Url != nil {
+		return *x.Url
+	}
+	return ""
+}
+
+func (x *ScrapeJobRequest) GetDescription() string {
+	if x != nil && x.Description != nil {
+		return *x.Description
 	}
 	return ""
 }
@@ -1341,10 +1349,13 @@ var File_api_proto_letraz_v1_letraz_utils_proto protoreflect.FileDescriptor
 
 const file_api_proto_letraz_v1_letraz_utils_proto_rawDesc = "" +
 	"\n" +
-	"&api/proto/letraz/v1/letraz-utils.proto\x12\tletraz.v1\x1a\x1cgoogle/protobuf/struct.proto\"X\n" +
-	"\x10ScrapeJobRequest\x12\x10\n" +
-	"\x03url\x18\x01 \x01(\tR\x03url\x122\n" +
-	"\aoptions\x18\x02 \x01(\v2\x18.letraz.v1.ScrapeOptionsR\aoptions\"\x97\x01\n" +
+	"&api/proto/letraz/v1/letraz-utils.proto\x12\tletraz.v1\x1a\x1cgoogle/protobuf/struct.proto\"\x9c\x01\n" +
+	"\x10ScrapeJobRequest\x12\x15\n" +
+	"\x03url\x18\x01 \x01(\tH\x00R\x03url\x88\x01\x01\x12%\n" +
+	"\vdescription\x18\x02 \x01(\tH\x01R\vdescription\x88\x01\x01\x122\n" +
+	"\aoptions\x18\x03 \x01(\v2\x18.letraz.v1.ScrapeOptionsR\aoptionsB\x06\n" +
+	"\x04_urlB\x0e\n" +
+	"\f_description\"\x97\x01\n" +
 	"\x11ScrapeJobResponse\x12\x1c\n" +
 	"\tprocessId\x18\x01 \x01(\tR\tprocessId\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x18\n" +
@@ -1543,6 +1554,7 @@ func file_api_proto_letraz_v1_letraz_utils_proto_init() {
 	if File_api_proto_letraz_v1_letraz_utils_proto != nil {
 		return
 	}
+	file_api_proto_letraz_v1_letraz_utils_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/api/proto/letraz/v1/letraz-utils.proto
+++ b/api/proto/letraz/v1/letraz-utils.proto
@@ -29,8 +29,9 @@ service HealthService {
 // ===== SCRAPER MESSAGES =====
 
 message ScrapeJobRequest {
-  string url = 1;
-  ScrapeOptions options = 2;
+  optional string url = 1;
+  optional string description = 2;
+  ScrapeOptions options = 3;
 }
 
 message ScrapeJobResponse {

--- a/internal/llm/interface.go
+++ b/internal/llm/interface.go
@@ -10,6 +10,9 @@ type LLMProvider interface {
 	// ExtractJobData processes HTML content and extracts structured job data
 	ExtractJobData(ctx context.Context, html, url string) (*models.Job, error)
 
+	// ExtractJobFromDescription processes job description text directly and extracts structured job data
+	ExtractJobFromDescription(ctx context.Context, description string) (*models.Job, error)
+
 	// TailorResume tailors a base resume for a specific job posting
 	TailorResume(ctx context.Context, baseResume *models.BaseResume, job *models.Job) (*models.TailoredResume, []models.Suggestion, error)
 

--- a/internal/llm/manager.go
+++ b/internal/llm/manager.go
@@ -96,6 +96,24 @@ func (m *Manager) ExtractJobData(ctx context.Context, html, url string) (*models
 	return provider.ExtractJobData(ctx, html, url)
 }
 
+// ExtractJobFromDescription extracts job data from description text using the configured LLM provider
+func (m *Manager) ExtractJobFromDescription(ctx context.Context, description string) (*models.Job, error) {
+	m.mu.RLock()
+	provider := m.provider
+	healthy := m.healthy
+	m.mu.RUnlock()
+
+	if provider == nil {
+		return nil, fmt.Errorf("LLM manager not started or provider not available")
+	}
+
+	if !healthy {
+		return nil, fmt.Errorf("LLM provider is not available - check API key configuration (set LLM_API_KEY environment variable)")
+	}
+
+	return provider.ExtractJobFromDescription(ctx, description)
+}
+
 // TailorResume tailors a resume for a specific job using the configured LLM provider
 func (m *Manager) TailorResume(ctx context.Context, baseResume *models.BaseResume, job *models.Job) (*models.TailoredResume, []models.Suggestion, error) {
 	m.mu.RLock()

--- a/internal/llm/providers/claude.go
+++ b/internal/llm/providers/claude.go
@@ -210,7 +210,7 @@ Return a JSON object with exactly these fields:
   "confidence": 1.0,
   "title": "string - The job title",
   "job_url": "",
-  "company_name": "string - The company name (if mentioned)",
+  "company_name": "string - The company name (extract from description or use 'Company Name Not Specified' if not mentioned)",
   "location": "string - The job location (city, state, country, or 'Remote')",
   "salary": {
     "currency": "string - The currency salary is being mentioned in (e.g., 'USD' or 'INR')",

--- a/pkg/models/request.go
+++ b/pkg/models/request.go
@@ -4,8 +4,9 @@ import "time"
 
 // ScrapeRequest represents the request payload for scraping a job posting
 type ScrapeRequest struct {
-	URL     string         `json:"url" validate:"required,url"`
-	Options *ScrapeOptions `json:"options,omitempty"`
+	URL         string         `json:"url" validate:"omitempty,url"`
+	Description string         `json:"description,omitempty"`
+	Options     *ScrapeOptions `json:"options,omitempty"`
 }
 
 // ScrapeOptions provides additional configuration for scraping requests


### PR DESCRIPTION
### Issue:
[LTB-79 | core: Accept job description for ScrapeJob request as a parameter along with URL](https://linear.app/letraz/issue/LTB-79/core-accept-job-description-for-scrapejob-request-as-a-parameter-along)

### Description:
Enhancing the `ScrapeJob` gRPC method to accept a job description directly, enabling users to bypass web scraping and proceed to AI-powered parsing.

### Changes Made:
- Updated `ScrapeJob` gRPC method to accept `job_description` alongside `url`.
- Implemented logic to skip web scraping if `description` is provided.
- Integrated LLM-based job parsing with provided description.
- Ensured consistent `Job` object output regardless of input type.

### Closing Note:
This PR streamlines user workflow by allowing direct input of job descriptions, enhancing service flexibility and efficiency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for submitting job extraction requests using either a URL or a plain text job description.
  * Users can now provide a job description directly instead of a URL for job data extraction.

* **Bug Fixes**
  * Improved validation to ensure that either a URL or a description is provided, but not both.

* **Enhancements**
  * Task metadata and logs now indicate whether the request was processed via URL or description.
  * Improved error messages for invalid input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->