### PR TITLE
LTB-89 | bug: Generating thumbnail fails after one successful generation due to browser reusability issue

### DIFF
--- a/internal/scraper/engines/headed/screenshot.go
+++ b/internal/scraper/engines/headed/screenshot.go
@@ -102,8 +102,11 @@ func (ss *ScreenshotService) CaptureResumeScreenshot(ctx context.Context, resume
 		return nil, fmt.Errorf("failed to wait for page load: %w", err)
 	}
 
-	// Set A4 viewport for proper resume rendering (optimized for speed)
-	err = browserInstance.Page.SetViewport(&proto.EmulationSetDeviceMetricsOverride{
+	// Set A4 viewport for proper resume rendering (with dedicated timeout)
+	viewportCtx, viewportCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer viewportCancel()
+
+	err = browserInstance.Page.Context(viewportCtx).SetViewport(&proto.EmulationSetDeviceMetricsOverride{
 		Width:             794,  // A4 width at 96 DPI (210mm)
 		Height:            1123, // A4 height at 96 DPI (297mm)
 		DeviceScaleFactor: 1,    // Standard DPI for faster rendering

--- a/internal/scraper/engines/headed/screenshot.go
+++ b/internal/scraper/engines/headed/screenshot.go
@@ -103,7 +103,7 @@ func (ss *ScreenshotService) CaptureResumeScreenshot(ctx context.Context, resume
 	}
 
 	// Set A4 viewport for proper resume rendering (with dedicated timeout)
-	viewportCtx, viewportCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	viewportCtx, viewportCancel := context.WithTimeout(screenshotCtx, 5*time.Second)
 	defer viewportCancel()
 
 	err = browserInstance.Page.Context(viewportCtx).SetViewport(&proto.EmulationSetDeviceMetricsOverride{


### PR DESCRIPTION
### Issue:
[LTB-89 | bug: Generating thumbnail fails after one successful generation due to browser reusability issue](https://linear.app/letraz/issue/LTB-89/bug-generating-thumbnail-fails-after-one-successful-generation-due-to)

### Description:
Fixing the issue where thumbnail generation fails after one successful attempt due to improper browser reusability handling.

### Changes Made:
- Implemented proper browser lifecycle management to ensure correct reset or closure after each thumbnail generation request.
- Introduced a browser pool mechanism to reuse `Rod` browser instances efficiently.
- Ensured explicit closure of browser pages after use to prevent memory and CPU leaks.
- Added error handling for browser and page operations to log and handle cleanup failures.
- Ensured concurrency safety by implementing thread-safe access to shared browser instances.

### Closing Note:
This PR is crucial to ensure consistent and reliable thumbnail generation by addressing the browser reusability issue that causes failures after the initial successful generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser pool management to prevent errors when launching new browsers and ensure accurate tracking of browser instances.
  * Enhanced health checks for browsers, making them more robust against transient issues.
  * Adjusted browser cleanup timing and logging for better reliability and transparency.
  * Set a timeout for viewport adjustments during screenshot capture to prevent indefinite hangs.

* **Chores**
  * Improved logging for browser reuse, closure, and health checks to aid in monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->