### PR TITLE
LTB-93 | core: Generate PDF documents from intermediate .tex files for resumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o bin/letraz-utils 
 # Production stage
 FROM alpine:latest
 
-# Install runtime dependencies including Chrome for headed scraping and TeX Live for LaTeX compilation
+# Install runtime dependencies including Chrome for headed scraping
 RUN apk add --no-cache \
     ca-certificates \
     tzdata \
     chromium \
     chromium-chromedriver \
-    texlive-full \
-    ghostscript \
     && rm -rf /var/cache/apk/*
 
 # Create non-root user
@@ -56,7 +54,6 @@ USER utilsuser
 ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/bin/chromium-browser
 ENV PATH="/usr/bin:$PATH"
-ENV TEXMFVAR=/app/tmp/texmf-var
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,14 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o bin/letraz-utils 
 # Production stage
 FROM alpine:latest
 
-# Install runtime dependencies including Chrome for headed scraping
+# Install runtime dependencies including Chrome for headed scraping and TeX Live for LaTeX compilation
 RUN apk add --no-cache \
     ca-certificates \
     tzdata \
     chromium \
     chromium-chromedriver \
+    texlive-full \
+    ghostscript \
     && rm -rf /var/cache/apk/*
 
 # Create non-root user
@@ -53,6 +55,8 @@ USER utilsuser
 # Set environment variables for Chrome
 ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/bin/chromium-browser
+ENV PATH="/usr/bin:$PATH"
+ENV TEXMFVAR=/app/tmp/texmf-var
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/Dockerfile.pdf-renderer
+++ b/Dockerfile.pdf-renderer
@@ -1,0 +1,47 @@
+# Dedicated PDF renderer image with TeX Live
+FROM debian:stable-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       tzdata \
+       curl \
+       gosu \
+       texlive-full \
+       ghostscript \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd -u 1001 -m renderer
+
+WORKDIR /srv
+
+# Copy only the renderer service
+COPY cmd/pdf-renderer/ cmd/pdf-renderer/
+
+# Build the small Go server inside the image using distro's Go if available? We'll use a multi-stage with Go.
+FROM golang:1.23-bullseye AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd/pdf-renderer/ cmd/pdf-renderer/
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/pdf-renderer ./cmd/pdf-renderer
+
+FROM debian:stable-slim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates tzdata curl texlive-full ghostscript \
+    && rm -rf /var/lib/apt/lists/*
+RUN useradd -u 1001 -m renderer
+WORKDIR /srv
+COPY --from=builder /out/pdf-renderer /usr/local/bin/pdf-renderer
+USER renderer
+EXPOSE 8999
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -fsS http://localhost:8999/health || exit 1
+ENV TEXMFVAR=/tmp/texmf-var
+CMD ["/usr/local/bin/pdf-renderer"]
+
+

--- a/Dockerfile.pdf-renderer
+++ b/Dockerfile.pdf-renderer
@@ -1,26 +1,3 @@
-# Dedicated PDF renderer image with TeX Live
-FROM debian:stable-slim
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       ca-certificates \
-       tzdata \
-       curl \
-       gosu \
-       texlive-full \
-       ghostscript \
-    && rm -rf /var/lib/apt/lists/*
-
-# Create non-root user
-RUN useradd -u 1001 -m renderer
-
-WORKDIR /srv
-
-# Copy only the renderer service
-COPY cmd/pdf-renderer/ cmd/pdf-renderer/
-
 # Build the small Go server inside the image using distro's Go if available? We'll use a multi-stage with Go.
 FROM golang:1.23-bullseye AS builder
 WORKDIR /src

--- a/api/proto/letraz/v1/letraz-utils.pb.go
+++ b/api/proto/letraz/v1/letraz-utils.pb.go
@@ -787,11 +787,12 @@ func (x *ExportResumeRequest) GetTheme() string {
 
 type ExportResumeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`                        // SUCCESS, FAILURE
-	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`                      // Status message
-	Timestamp     string                 `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`                  // ISO timestamp string
-	ExportUrl     string                 `protobuf:"bytes,4,opt,name=export_url,json=exportUrl,proto3" json:"export_url,omitempty"` // CDN URL of the uploaded .tex file
-	Error         string                 `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`                          // Error code/type (only for failures)
+	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`                     // SUCCESS, FAILURE
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`                   // Status message
+	Timestamp     string                 `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`               // ISO timestamp string
+	LatexUrl      string                 `protobuf:"bytes,5,opt,name=latex_url,json=latexUrl,proto3" json:"latex_url,omitempty"` // CDN URL of the uploaded .tex file
+	PdfUrl        string                 `protobuf:"bytes,6,opt,name=pdf_url,json=pdfUrl,proto3" json:"pdf_url,omitempty"`       // CDN URL of the uploaded .pdf file
+	Error         string                 `protobuf:"bytes,7,opt,name=error,proto3" json:"error,omitempty"`                       // Error code/type (only for failures)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -847,9 +848,16 @@ func (x *ExportResumeResponse) GetTimestamp() string {
 	return ""
 }
 
-func (x *ExportResumeResponse) GetExportUrl() string {
+func (x *ExportResumeResponse) GetLatexUrl() string {
 	if x != nil {
-		return x.ExportUrl
+		return x.LatexUrl
+	}
+	return ""
+}
+
+func (x *ExportResumeResponse) GetPdfUrl() string {
+	if x != nil {
+		return x.PdfUrl
 	}
 	return ""
 }
@@ -1298,14 +1306,15 @@ const file_api_proto_letraz_v1_letraz_utils_proto_rawDesc = "" +
 	"\x05error\x18\x06 \x01(\tR\x05error\"Z\n" +
 	"\x13ExportResumeRequest\x12-\n" +
 	"\x06resume\x18\x01 \x01(\v2\x15.letraz.v1.BaseResumeR\x06resume\x12\x14\n" +
-	"\x05theme\x18\x02 \x01(\tR\x05theme\"\x9b\x01\n" +
+	"\x05theme\x18\x02 \x01(\tR\x05theme\"\xc4\x01\n" +
 	"\x14ExportResumeResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1c\n" +
-	"\ttimestamp\x18\x03 \x01(\tR\ttimestamp\x12\x1d\n" +
-	"\n" +
-	"export_url\x18\x04 \x01(\tR\texportUrl\x12\x14\n" +
-	"\x05error\x18\x05 \x01(\tR\x05error\"\x14\n" +
+	"\ttimestamp\x18\x03 \x01(\tR\ttimestamp\x12\x1b\n" +
+	"\tlatex_url\x18\x05 \x01(\tR\blatexUrl\x12\x17\n" +
+	"\apdf_url\x18\x06 \x01(\tR\x06pdfUrl\x12\x14\n" +
+	"\x05error\x18\a \x01(\tR\x05errorJ\x04\b\x04\x10\x05R\n" +
+	"export_url\"\x14\n" +
 	"\x12HealthCheckRequest\"\x8b\x02\n" +
 	"\x13HealthCheckResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1c\n" +

--- a/api/proto/letraz/v1/letraz-utils.proto
+++ b/api/proto/letraz/v1/letraz-utils.proto
@@ -122,11 +122,16 @@ message ExportResumeRequest {
 }
 
 message ExportResumeResponse {
+  // Reserve removed field to avoid accidental reuse
+  reserved 4;
+  reserved "export_url";
+
   string status = 1;         // SUCCESS, FAILURE
   string message = 2;        // Status message
   string timestamp = 3;      // ISO timestamp string
-  string export_url = 4;     // CDN URL of the uploaded .tex file
-  string error = 5;          // Error code/type (only for failures)
+  string latex_url = 5;      // CDN URL of the uploaded .tex file
+  string pdf_url = 6;        // CDN URL of the uploaded .pdf file
+  string error = 7;          // Error code/type (only for failures)
 }
 
 // ===== HEALTH MESSAGES =====

--- a/cmd/pdf-renderer/main.go
+++ b/cmd/pdf-renderer/main.go
@@ -2,15 +2,23 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
 	"strings"
+	"syscall"
+	"time"
 )
 
 type compileRequest struct {
@@ -28,6 +36,10 @@ func compileHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bound request body size to prevent memory abuse
+	const maxRequestBytes = 1 << 20 // 1 MiB
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
+
 	var req compileRequest
 	dec := json.NewDecoder(r.Body)
 	if err := dec.Decode(&req); err != nil {
@@ -39,6 +51,16 @@ func compileHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate input size and strip dangerous primitives
+	if len(req.Latex) > 500_000 { // ~500 KB cap for LaTeX source
+		http.Error(w, "latex input too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	if err := validateLatex(req.Latex); err != nil {
+		http.Error(w, fmt.Sprintf("latex rejected: %v", err), http.StatusBadRequest)
+		return
+	}
+
 	workDir, err := os.MkdirTemp("/tmp", "latex-build-*")
 	if err != nil {
 		http.Error(w, fmt.Sprintf("create temp dir: %v", err), http.StatusInternalServerError)
@@ -47,27 +69,29 @@ func compileHandler(w http.ResponseWriter, r *http.Request) {
 	defer os.RemoveAll(workDir)
 
 	texFile := filepath.Join(workDir, "document.tex")
-	if err := os.WriteFile(texFile, []byte(req.Latex), 0644); err != nil {
+	if err := os.WriteFile(texFile, []byte(req.Latex), 0600); err != nil {
 		http.Error(w, fmt.Sprintf("write tex file: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	// Prefer latexmk for multi-pass builds if available; fallback to pdflatex
+	// Build command and enforce security mitigations
 	var out bytes.Buffer
-	var cmd *exec.Cmd
-	if _, err := exec.LookPath("latexmk"); err == nil {
-		cmd = exec.Command("latexmk", "-pdf", "-interaction=nonstopmode", "-halt-on-error", "-outdir="+workDir, texFile)
-	} else {
-		cmd = exec.Command("pdflatex", "-interaction=nonstopmode", "-halt-on-error", "-output-directory", workDir, texFile)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	cmd, err := buildLatexCommand(ctx, workDir, texFile)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("build command: %v", err), http.StatusInternalServerError)
+		return
 	}
-	cmd.Dir = workDir
-	env := os.Environ()
-	env = append(env, "TEXMFVAR=/tmp/texmf-var")
-	cmd.Env = env
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 
 	if err := cmd.Run(); err != nil {
+		// Kill entire process group on timeout or error
+		if ctx.Err() == context.DeadlineExceeded && cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
 		http.Error(w, fmt.Sprintf("latex compile failed: %v\n%s", err, out.String()), http.StatusBadRequest)
 		return
 	}
@@ -100,4 +124,179 @@ func main() {
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
+}
+
+// buildLatexCommand constructs the LaTeX compilation command with security mitigations.
+func buildLatexCommand(ctx context.Context, workDir, texFile string) (*exec.Cmd, error) {
+	// Compose the base LaTeX command with shell-escape disabled
+	var args []string
+	if _, err := exec.LookPath("latexmk"); err == nil {
+		// Ensure pdflatex invoked by latexmk also has -no-shell-escape
+		pdflatex := "pdflatex -interaction=nonstopmode -halt-on-error -no-shell-escape"
+		args = []string{
+			"latexmk",
+			"-pdf",
+			"-interaction=nonstopmode",
+			"-halt-on-error",
+			"-outdir=" + workDir,
+			"-pdflatex=" + pdflatex,
+			texFile,
+		}
+	} else {
+		args = []string{
+			"pdflatex",
+			"-interaction=nonstopmode",
+			"-halt-on-error",
+			"-no-shell-escape",
+			"-output-directory",
+			workDir,
+			texFile,
+		}
+	}
+
+	// Apply OS-level resource limits via a shell wrapper (portable)
+	// Limits: CPU seconds, virtual memory, max output file size, file descriptors
+	maxCPUSeconds := 20
+	maxAddressSpaceKB := 512 * 1024 // 512 MiB
+	maxPDFBytes := int64(200 * 1024 * 1024)
+	// ulimit -f expects 512-byte blocks on most systems
+	maxFileBlocks := (maxPDFBytes + 511) / 512
+
+	latexCmdStr := shellJoin(args)
+	shCmd := fmt.Sprintf("ulimit -t %d; ulimit -v %d; ulimit -f %d; ulimit -n 32; exec %s", maxCPUSeconds, maxAddressSpaceKB, maxFileBlocks, latexCmdStr)
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", shCmd)
+	cmd.Dir = workDir
+
+	// Minimal, controlled environment
+	env := []string{
+		"PATH=/usr/bin:/bin:/usr/local/bin",
+		"HOME=" + workDir,
+		"TEXMFVAR=" + filepath.Join(workDir, "texmf-var"),
+		// Avoid inheriting proxies or other sensitive env vars
+		"NO_PROXY=*",
+		"http_proxy=",
+		"https_proxy=",
+	}
+	// Preserve locale if present to avoid LaTeX font issues
+	for _, key := range []string{"LANG", "LC_ALL", "LC_CTYPE"} {
+		if val, ok := lookupEnvExact(key); ok {
+			env = append(env, key+"="+val)
+		}
+	}
+	cmd.Env = env
+
+	// Create a new process group so we can kill children
+	sys := &syscall.SysProcAttr{Setpgid: true}
+
+	// Drop privileges if running as root
+	if os.Geteuid() == 0 {
+		if cred, err := nobodyCredential(); err == nil {
+			sys.Credential = cred
+		}
+		// On Linux we could also set seccomp/apparmor here via containerization; omitted here.
+	}
+	cmd.SysProcAttr = sys
+
+	return cmd, nil
+}
+
+func lookupEnvExact(key string) (string, bool) {
+	for _, kv := range os.Environ() {
+		if i := strings.IndexByte(kv, '='); i > 0 && kv[:i] == key {
+			return kv[i+1:], true
+		}
+	}
+	return "", false
+}
+
+func nobodyCredential() (*syscall.Credential, error) {
+	u, err := user.Lookup("nobody")
+	if err != nil {
+		return nil, err
+	}
+	uid64, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	gid64, err := strconv.ParseUint(u.Gid, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	cred := &syscall.Credential{Uid: uint32(uid64), Gid: uint32(gid64)}
+	return cred, nil
+}
+
+// validateLatex performs simple static checks to reject dangerous primitives and paths.
+func validateLatex(src string) error {
+	s := src
+	if len(s) == 0 {
+		return errors.New("empty input")
+	}
+	// Normalize to lower for simple substring checks where case-insensitive
+	lower := strings.ToLower(s)
+
+	// Denylist of obviously dangerous primitives
+	denySubs := []string{
+		`\\write18`,
+		`\\openout`,
+		`\\openin`,
+		`\\read`,
+		`\\immediate\\s*\\write`,
+	}
+	for _, pat := range denySubs {
+		re := regexp.MustCompile(pat)
+		if re.MatchString(lower) {
+			return fmt.Errorf("contains forbidden primitive: %s", pat)
+		}
+	}
+
+	// Disallow packages known to re-enable shell-escape or file IO conveniences
+	badPkgs := []string{"shellesc", "write18", "catchfile", "verbatiminput"}
+	for _, p := range badPkgs {
+		re := regexp.MustCompile(`\\usepackage\s*\{[^}]*` + regexp.QuoteMeta(p) + `[^}]*\}`)
+		if re.MatchString(lower) {
+			return fmt.Errorf("forbidden package: %s", p)
+		}
+	}
+
+	// Block \input or \include of absolute paths or URLs
+	reInput := regexp.MustCompile(`\\(input|include)\s*\{([^}]*)\}`)
+	matches := reInput.FindAllStringSubmatch(lower, -1)
+	for _, m := range matches {
+		if len(m) >= 3 {
+			arg := strings.TrimSpace(m[2])
+			if strings.HasPrefix(arg, "/") || strings.Contains(arg, `://`) || strings.Contains(arg, `..`) {
+				return fmt.Errorf("forbidden include path: %s", arg)
+			}
+		}
+	}
+
+	// Basic cap on number of includes to avoid pathological recursion
+	if len(matches) > 32 {
+		return fmt.Errorf("too many includes: %d", len(matches))
+	}
+
+	// On non-Unix platforms or unusual runtimes, be extra conservative
+	if runtime.GOOS == "windows" {
+		return errors.New("unsupported platform")
+	}
+	return nil
+}
+
+// shellJoin safely quotes arguments for a POSIX shell.
+func shellJoin(args []string) string {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		out = append(out, shellQuote(a))
+	}
+	return strings.Join(out, " ")
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	// Replace every ' with '\'' and wrap in single quotes
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/cmd/pdf-renderer/main.go
+++ b/cmd/pdf-renderer/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type compileRequest struct {
+	Latex string `json:"latex"`
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func compileHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req compileRequest
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid json: %v", err), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Latex) == "" {
+		http.Error(w, "latex is required", http.StatusBadRequest)
+		return
+	}
+
+	workDir, err := os.MkdirTemp("/tmp", "latex-build-*")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("create temp dir: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer os.RemoveAll(workDir)
+
+	texFile := filepath.Join(workDir, "document.tex")
+	if err := os.WriteFile(texFile, []byte(req.Latex), 0644); err != nil {
+		http.Error(w, fmt.Sprintf("write tex file: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Prefer latexmk for multi-pass builds if available; fallback to pdflatex
+	var out bytes.Buffer
+	var cmd *exec.Cmd
+	if _, err := exec.LookPath("latexmk"); err == nil {
+		cmd = exec.Command("latexmk", "-pdf", "-interaction=nonstopmode", "-halt-on-error", "-outdir="+workDir, texFile)
+	} else {
+		cmd = exec.Command("pdflatex", "-interaction=nonstopmode", "-halt-on-error", "-output-directory", workDir, texFile)
+	}
+	cmd.Dir = workDir
+	env := os.Environ()
+	env = append(env, "TEXMFVAR=/tmp/texmf-var")
+	cmd.Env = env
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Run(); err != nil {
+		http.Error(w, fmt.Sprintf("latex compile failed: %v\n%s", err, out.String()), http.StatusBadRequest)
+		return
+	}
+
+	pdfPath := filepath.Join(workDir, "document.pdf")
+	f, err := os.Open(pdfPath)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read pdf: %v\n%s", err, out.String()), http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	w.Header().Set("Content-Type", "application/pdf")
+	w.WriteHeader(http.StatusOK)
+	if _, err := io.Copy(w, f); err != nil {
+		log.Printf("write response: %v", err)
+	}
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", healthHandler)
+	mux.HandleFunc("/compile", compileHandler)
+
+	addr := ":8999"
+	if v := os.Getenv("PORT"); strings.TrimSpace(v) != "" {
+		addr = ":" + v
+	}
+	log.Printf("pdf-renderer listening on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: "3.9"
-
 services:
   letraz-utils:
     image: letraz-utils:latest
     container_name: letraz-utils
+    depends_on:
+      - pdf-renderer
     env_file:
       - .env
     ports:
@@ -17,6 +17,21 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    environment:
+      - PDF_RENDERER_URL=http://pdf-renderer:8999
     # Uncomment if you want it to always restart unless stopped manually
     # restart: unless-stopped
+
+  pdf-renderer:
+    build:
+      context: .
+      dockerfile: Dockerfile.pdf-renderer
+    image: letraz-pdf-renderer:latest
+    container_name: letraz-pdf-renderer
+    expose:
+      - "8999"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8999/health"]
+      interval: 30s
+    restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,9 @@ services:
     # restart: unless-stopped
 
   pdf-renderer:
-    build:
-      context: .
-      dockerfile: Dockerfile.pdf-renderer
-    image: letraz-pdf-renderer:latest
+    image: ghcr.io/letrazapp/pdf-renderer:latest
     container_name: letraz-pdf-renderer
+    pull_policy: always
     expose:
       - "8999"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+
+services:
+  letraz-utils:
+    image: letraz-utils:latest
+    container_name: letraz-utils
+    env_file:
+      - .env
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs
+      - ./tmp:/app/tmp
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    # Uncomment if you want it to always restart unless stopped manually
+    # restart: unless-stopped
+

--- a/internal/api/handlers/resume.go
+++ b/internal/api/handlers/resume.go
@@ -177,7 +177,7 @@ func ExportResumeHandler(cfg *config.Config) echo.HandlerFunc {
 		}
 
 		// Render and upload via shared exporter
-		url, err := exporter.ExportResume(c.Request().Context(), cfg, *req.Resume, req.Theme)
+		latexURL, pdfURL, err := exporter.ExportResume(c.Request().Context(), cfg, *req.Resume, req.Theme)
 		if err != nil {
 			// Map well-known sentinel errors to stable codes
 			code := "INTERNAL"
@@ -200,9 +200,10 @@ func ExportResumeHandler(cfg *config.Config) echo.HandlerFunc {
 		}
 
 		return c.JSON(http.StatusOK, map[string]interface{}{
-			"status":     "SUCCESS",
-			"message":    "Exported successfully",
-			"export_url": url,
+			"status":    "SUCCESS",
+			"message":   "Exported successfully",
+			"latex_url": latexURL,
+			"pdf_url":   pdfURL,
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,10 @@ type Config struct {
 		MaxRetries    int           `yaml:"max_retries" default:"3"`
 		Enabled       bool          `yaml:"enabled" default:"true"`
 	} `yaml:"callback"`
+
+	PDFRenderer struct {
+		URL string `yaml:"url"` // e.g., http://pdf-renderer:8999
+	} `yaml:"pdf_renderer"`
 }
 
 // expandEnvVars expands environment variables in a string using ${VAR} or $VAR syntax
@@ -437,6 +441,11 @@ func (c *Config) loadFromEnv() {
 
 	// Handle additional logging adapter options via environment variables
 	c.loadLoggingAdapterEnvVars()
+
+	// PDF renderer URL
+	if pdfURL := os.Getenv("PDF_RENDERER_URL"); pdfURL != "" {
+		c.PDFRenderer.URL = pdfURL
+	}
 }
 
 // loadLoggingAdapterEnvVars loads environment variables for logging adapters

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,7 +133,8 @@ type Config struct {
 	} `yaml:"callback"`
 
 	PDFRenderer struct {
-		URL string `yaml:"url"` // e.g., http://pdf-renderer:8999
+		URL     string        `yaml:"url"` // e.g., http://pdf-renderer:8999
+		Timeout time.Duration `yaml:"timeout" default:"30s"`
 	} `yaml:"pdf_renderer"`
 }
 
@@ -224,6 +225,9 @@ func LoadConfig(configPath string) (*Config, error) {
 	config.Callback.Timeout = 30 * time.Second
 	config.Callback.MaxRetries = 3
 	config.Callback.Enabled = true
+
+	// PDF renderer defaults
+	config.PDFRenderer.Timeout = 30 * time.Second
 
 	// Load from YAML file if it exists
 	if configPath != "" {
@@ -445,6 +449,13 @@ func (c *Config) loadFromEnv() {
 	// PDF renderer URL
 	if pdfURL := os.Getenv("PDF_RENDERER_URL"); pdfURL != "" {
 		c.PDFRenderer.URL = pdfURL
+	}
+
+	// PDF renderer timeout
+	if pdfTimeout := os.Getenv("PDF_RENDERER_TIMEOUT"); pdfTimeout != "" {
+		if timeout, err := time.ParseDuration(pdfTimeout); err == nil {
+			c.PDFRenderer.Timeout = timeout
+		}
 	}
 }
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -19,9 +19,9 @@ var (
 	ErrUpload        = errors.New("upload_failed")
 )
 
-// ExportResume renders a resume into LaTeX using the given theme and uploads the .tex file to Spaces.
-// Returns the public URL of the uploaded file.
-func ExportResume(_ context.Context, cfg *config.Config, resume models.BaseResume, theme string) (string, error) {
+// ExportResume renders a resume into LaTeX using the given theme, compiles a PDF,
+// uploads both artifacts to Spaces, and returns their public URLs (latexURL, pdfURL).
+func ExportResume(_ context.Context, cfg *config.Config, resume models.BaseResume, theme string) (string, string, error) {
 	logger := logging.GetGlobalLogger()
 
 	// Render LaTeX
@@ -33,7 +33,18 @@ func ExportResume(_ context.Context, cfg *config.Config, resume models.BaseResum
 			"theme":     theme,
 			"error":     err.Error(),
 		})
-		return "", fmt.Errorf("%w: %v", ErrRender, err)
+		return "", "", fmt.Errorf("%w: %v", ErrRender, err)
+	}
+
+	// Compile PDF using LaTeX toolchain
+	pdfBytes, err := latex.Compile(latexStr)
+	if err != nil {
+		logger.Error("Failed to compile LaTeX to PDF", map[string]interface{}{
+			"resume_id": resume.ID,
+			"theme":     theme,
+			"error":     err.Error(),
+		})
+		return "", "", fmt.Errorf("%w: %v", ErrRender, err)
 	}
 
 	// Init Spaces client
@@ -43,18 +54,33 @@ func ExportResume(_ context.Context, cfg *config.Config, resume models.BaseResum
 			"resume_id": resume.ID,
 			"error":     err.Error(),
 		})
-		return "", fmt.Errorf("%w: %v", ErrStorageConfig, err)
+		return "", "", fmt.Errorf("%w: %v", ErrStorageConfig, err)
 	}
 
+	// To keep both files paired, generate a common base filename
+	baseFile := utils.GenerateRequestID()
+	texName := baseFile + ".tex"
+	pdfName := baseFile + ".pdf"
+
 	// Upload .tex
-	url, err := spaces.UploadLatexExport(resume.ID, "", []byte(latexStr))
+	latexURL, err := spaces.UploadLatexExport(resume.ID, texName, []byte(latexStr))
 	if err != nil {
 		logger.Error("Failed to upload LaTeX export", map[string]interface{}{
 			"resume_id": resume.ID,
 			"error":     err.Error(),
 		})
-		return "", fmt.Errorf("%w: %v", ErrUpload, err)
+		return "", "", fmt.Errorf("%w: %v", ErrUpload, err)
 	}
 
-	return url, nil
+	// Upload .pdf
+	pdfURL, err := spaces.UploadPDFExport(resume.ID, pdfName, pdfBytes)
+	if err != nil {
+		logger.Error("Failed to upload PDF export", map[string]interface{}{
+			"resume_id": resume.ID,
+			"error":     err.Error(),
+		})
+		return "", "", fmt.Errorf("%w: %v", ErrUpload, err)
+	}
+
+	return latexURL, pdfURL, nil
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -15,6 +15,7 @@ import (
 // Sentinel errors to allow precise mapping in handlers
 var (
 	ErrRender        = errors.New("render_error")
+	ErrCompile       = errors.New("compile_error")
 	ErrStorageConfig = errors.New("storage_configuration")
 	ErrUpload        = errors.New("upload_failed")
 )
@@ -37,14 +38,14 @@ func ExportResume(_ context.Context, cfg *config.Config, resume models.BaseResum
 	}
 
 	// Compile PDF using LaTeX toolchain
-	pdfBytes, err := latex.Compile(latexStr)
+	pdfBytes, err := latex.Compile(cfg, latexStr)
 	if err != nil {
 		logger.Error("Failed to compile LaTeX to PDF", map[string]interface{}{
 			"resume_id": resume.ID,
 			"theme":     theme,
 			"error":     err.Error(),
 		})
-		return "", "", fmt.Errorf("%w: %v", ErrRender, err)
+		return "", "", fmt.Errorf("%w: %v", ErrCompile, err)
 	}
 
 	// Init Spaces client
@@ -67,19 +68,22 @@ func ExportResume(_ context.Context, cfg *config.Config, resume models.BaseResum
 	if err != nil {
 		logger.Error("Failed to upload LaTeX export", map[string]interface{}{
 			"resume_id": resume.ID,
+			"tex_name":  texName,
 			"error":     err.Error(),
 		})
-		return "", "", fmt.Errorf("%w: %v", ErrUpload, err)
+		return "", "", ErrUpload
 	}
-
 	// Upload .pdf
 	pdfURL, err := spaces.UploadPDFExport(resume.ID, pdfName, pdfBytes)
 	if err != nil {
+		// Best-effort cleanup of previously uploaded .tex
+		_ = spaces.DeleteExportObject(resume.ID, texName)
 		logger.Error("Failed to upload PDF export", map[string]interface{}{
 			"resume_id": resume.ID,
+			"pdf_name":  pdfName,
 			"error":     err.Error(),
 		})
-		return "", "", fmt.Errorf("%w: %v", ErrUpload, err)
+		return "", "", ErrUpload
 	}
 
 	return latexURL, pdfURL, nil

--- a/internal/grpc/server/resume.go
+++ b/internal/grpc/server/resume.go
@@ -329,7 +329,7 @@ func (s *Server) ExportResume(ctx context.Context, req *letrazv1.ExportResumeReq
 	resume := convertGRPCBaseResumeToModel(req.GetResume())
 
 	// Render and upload via shared exporter
-	url, err := exporter.ExportResume(ctx, s.cfg, *resume, req.GetTheme())
+	latexURL, pdfURL, err := exporter.ExportResume(ctx, s.cfg, *resume, req.GetTheme())
 	if err != nil {
 		statusCode := "INTERNAL"
 		message := err.Error()
@@ -355,6 +355,7 @@ func (s *Server) ExportResume(ctx context.Context, req *letrazv1.ExportResumeReq
 		Status:    "SUCCESS",
 		Message:   "Exported successfully",
 		Timestamp: time.Now().Format(time.RFC3339Nano),
-		ExportUrl: url,
+		LatexUrl:  latexURL,
+		PdfUrl:    pdfURL,
 	}, nil
 }

--- a/internal/latex/compiler.go
+++ b/internal/latex/compiler.go
@@ -2,6 +2,8 @@ package latex
 
 import (
 	"bytes"
+	"context"
+	"enc
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,24 +12,36 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"letraz-utils/internal/config"
 )
 
 // Compile takes LaTeX source and compiles it to PDF using pdflatex.
 // Returns the produced PDF bytes or an error containing the LaTeX log on failure.
-func Compile(latexSource string) ([]byte, error) {
+func Compile(cfg *config.Config, latexSource string) ([]byte, error) {
 	if strings.TrimSpace(latexSource) == "" {
 		return nil, fmt.Errorf("empty LaTeX source")
 	}
 
-	// If a remote PDF renderer is configured via env, use it
-	if rendererURL := strings.TrimSpace(os.Getenv("PDF_RENDERER_URL")); rendererURL != "" {
-		body, _ := json.Marshal(map[string]string{"latex": latexSource})
+	// If a remote PDF renderer is configured via config, use it
+	if rendererURL := strings.TrimSpace(cfg.PDFRenderer.URL); rendererURL != "" {
+		body, err := json.Marshal(map[string]string{"latex": latexSource})
+		if err != nil {
+			return nil, fmt.Errorf("marshal latex payload: %w", err)
+		}
 		req, err := http.NewRequest(http.MethodPost, strings.TrimRight(rendererURL, "/")+"/compile", bytes.NewReader(body))
 		if err != nil {
 			return nil, fmt.Errorf("create request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
+		// Use timeout from configuration, with a sane default if unset
+		clientTimeout := 30 * time.Second
+		if cfg != nil && cfg.PDFRenderer.Timeout > 0 {
+			clientTimeout = cfg.PDFRenderer.Timeout
+		}
+		client := &http.Client{Timeout: clientTimeout}
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("renderer request failed: %w", err)
 		}
@@ -61,7 +75,15 @@ func Compile(latexSource string) ([]byte, error) {
 	}
 
 	// Prepare command; use nonstopmode and halt-on-error for deterministic behavior
-	cmd := exec.Command("pdflatex", "-interaction=nonstopmode", "-halt-on-error", "-output-directory", workDir, texFile)
+	// Use a context with timeout so runaway compilations are killed
+	compileTimeout := 30 * time.Second
+	if cfg != nil && cfg.PDFRenderer.Timeout > 0 {
+		compileTimeout = cfg.PDFRenderer.Timeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), compileTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "pdflatex", "-interaction=nonstopmode", "-halt-on-error", "-no-shell-escape", "-output-directory", workDir, texFile)
 	cmd.Dir = workDir
 
 	// Ensure TeX caches in writable location
@@ -74,7 +96,10 @@ func Compile(latexSource string) ([]byte, error) {
 	cmd.Stderr = &out
 
 	if err := cmd.Run(); err != nil {
-		// Return combined output to help diagnose missing packages
+		// Return combined output to help diagnose issues and handle timeouts clearly
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("pdflatex timed out after %s: %v; log:\n%s", compileTimeout, err, out.String())
+		}
 		return nil, fmt.Errorf("pdflatex failed: %w; log:\n%s", err, out.String())
 	}
 

--- a/internal/latex/compiler.go
+++ b/internal/latex/compiler.go
@@ -1,0 +1,59 @@
+package latex
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Compile takes LaTeX source and compiles it to PDF using pdflatex.
+// Returns the produced PDF bytes or an error containing the LaTeX log on failure.
+func Compile(latexSource string) ([]byte, error) {
+	if strings.TrimSpace(latexSource) == "" {
+		return nil, fmt.Errorf("empty LaTeX source")
+	}
+
+	// Create isolated working directory under tmp
+	workDir, err := os.MkdirTemp("/app/tmp", "latex-build-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	// Clean up on return
+	defer os.RemoveAll(workDir)
+
+	// Write LaTeX to file
+	texFile := filepath.Join(workDir, "document.tex")
+	if err := os.WriteFile(texFile, []byte(latexSource), 0644); err != nil {
+		return nil, fmt.Errorf("write tex file: %w", err)
+	}
+
+	// Prepare command; use nonstopmode and halt-on-error for deterministic behavior
+	cmd := exec.Command("pdflatex", "-interaction=nonstopmode", "-halt-on-error", "-output-directory", workDir, texFile)
+	cmd.Dir = workDir
+
+	// Ensure TeX caches in writable location
+	env := os.Environ()
+	env = append(env, "TEXMFVAR=/app/tmp/texmf-var")
+	cmd.Env = env
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Run(); err != nil {
+		// Return combined output to help diagnose missing packages
+		return nil, fmt.Errorf("pdflatex failed: %w; log:\n%s", err, out.String())
+	}
+
+	// Read produced PDF
+	pdfPath := filepath.Join(workDir, "document.pdf")
+	pdfBytes, err := os.ReadFile(pdfPath)
+	if err != nil {
+		return nil, fmt.Errorf("read pdf: %w; log:\n%s", err, out.String())
+	}
+
+	return pdfBytes, nil
+}

--- a/internal/latex/compiler.go
+++ b/internal/latex/compiler.go
@@ -3,7 +3,6 @@ package latex
 import (
 	"bytes"
 	"context"
-	"enc
 	"encoding/json"
 	"fmt"
 	"io"

--- a/pkg/utils/spaces.go
+++ b/pkg/utils/spaces.go
@@ -209,50 +209,61 @@ func (sc *SpacesClient) IsHealthy() bool {
 	return healthy
 }
 
-// UploadLatexExport uploads a LaTeX export to DigitalOcean Spaces under exports/<resumeId>/<random>.tex
-func (sc *SpacesClient) UploadLatexExport(resumeID string, fileName string, latexData []byte) (string, error) {
+// uploadExport centralizes the logic for uploading export artifacts to Spaces
+func (sc *SpacesClient) uploadExport(resumeID string, fileName string, data []byte, contentType string, ext string) (string, error) {
 	if resumeID == "" {
 		return "", fmt.Errorf("resumeID is required")
 	}
-	if len(latexData) == 0 {
-		return "", fmt.Errorf("latexData is empty")
+	if len(data) == 0 {
+		return "", fmt.Errorf("data is empty")
 	}
+	if ext == "" {
+		return "", fmt.Errorf("ext is required")
+	}
+	if !strings.HasPrefix(ext, ".") {
+		ext = "." + ext
+	}
+
 	if fileName == "" {
-		fileName = uuid.New().String() + ".tex"
+		fileName = uuid.New().String() + ext
 	} else {
 		// Normalize and constrain to a safe base name
 		fileName = filepath.Base(strings.TrimSpace(fileName))
 		if fileName == "." || fileName == "" {
-			fileName = uuid.New().String() + ".tex"
+			fileName = uuid.New().String() + ext
 		}
-		if !strings.HasSuffix(strings.ToLower(fileName), ".tex") {
-			fileName += ".tex"
+		if !strings.HasSuffix(strings.ToLower(fileName), strings.ToLower(ext)) {
+			fileName += ext
 		}
 	}
+
 	objectKey := fmt.Sprintf("exports/%s/%s", resumeID, fileName)
 
-	sc.logger.Info("Uploading LaTeX export to DigitalOcean Spaces", map[string]interface{}{
-		"resume_id":  resumeID,
-		"object_key": objectKey,
-		"size_bytes": len(latexData),
+	sc.logger.Info("Uploading export to DigitalOcean Spaces", map[string]interface{}{
+		"resume_id":    resumeID,
+		"object_key":   objectKey,
+		"size_bytes":   len(data),
+		"content_type": contentType,
 	})
 
 	_, err := sc.client.PutObject(&s3.PutObjectInput{
 		Bucket:      aws.String(sc.bucketName),
 		Key:         aws.String(objectKey),
-		Body:        bytes.NewReader(latexData),
-		ContentType: aws.String("application/x-tex"),
+		Body:        bytes.NewReader(data),
+		ContentType: aws.String(contentType),
 		ACL:         aws.String("public-read"),
 	})
 	if err != nil {
-		sc.logger.Error("Failed to upload LaTeX export to DigitalOcean Spaces", map[string]interface{}{
-			"resume_id":  resumeID,
-			"object_key": objectKey,
-			"error":      err.Error(),
+		sc.logger.Error("Failed to upload export to DigitalOcean Spaces", map[string]interface{}{
+			"resume_id":    resumeID,
+			"object_key":   objectKey,
+			"error":        err.Error(),
+			"content_type": contentType,
 		})
-		return "", fmt.Errorf("failed to upload LaTeX export: %w", err)
+		return "", fmt.Errorf("failed to upload export: %w", err)
 	}
 
+	// Construct the URL (prefer CDN, then bucket URL, then region-based URL)
 	var fileURL string
 	if sc.cdnURL != "" {
 		fileURL = fmt.Sprintf("%s/%s", strings.TrimRight(sc.cdnURL, "/"), objectKey)
@@ -270,7 +281,7 @@ func (sc *SpacesClient) UploadLatexExport(resumeID string, fileName string, late
 		fileURL = fmt.Sprintf("https://%s.%s.digitaloceanspaces.com/%s", sc.bucketName, region, objectKey)
 	}
 
-	sc.logger.Info("LaTeX export uploaded successfully", map[string]interface{}{
+	sc.logger.Info("Export uploaded successfully", map[string]interface{}{
 		"resume_id":  resumeID,
 		"object_key": objectKey,
 		"url":        fileURL,
@@ -279,71 +290,51 @@ func (sc *SpacesClient) UploadLatexExport(resumeID string, fileName string, late
 	return fileURL, nil
 }
 
+// UploadLatexExport uploads a LaTeX export to DigitalOcean Spaces under exports/<resumeId>/<random>.tex
+func (sc *SpacesClient) UploadLatexExport(resumeID string, fileName string, latexData []byte) (string, error) {
+	return sc.uploadExport(resumeID, fileName, latexData, "application/x-tex", ".tex")
+}
+
 // UploadPDFExport uploads a compiled PDF export to DigitalOcean Spaces under exports/<resumeId>/<fileName>.pdf
 func (sc *SpacesClient) UploadPDFExport(resumeID string, fileName string, pdfData []byte) (string, error) {
-	if resumeID == "" {
-		return "", fmt.Errorf("resumeID is required")
-	}
-	if len(pdfData) == 0 {
-		return "", fmt.Errorf("pdfData is empty")
-	}
-	if fileName == "" {
-		fileName = uuid.New().String() + ".pdf"
-	} else {
-		fileName = filepath.Base(strings.TrimSpace(fileName))
-		if fileName == "." || fileName == "" {
-			fileName = uuid.New().String() + ".pdf"
-		}
-		if !strings.HasSuffix(strings.ToLower(fileName), ".pdf") {
-			fileName += ".pdf"
-		}
-	}
-	objectKey := fmt.Sprintf("exports/%s/%s", resumeID, fileName)
+	return sc.uploadExport(resumeID, fileName, pdfData, "application/pdf", ".pdf")
+}
 
-	sc.logger.Info("Uploading PDF export to DigitalOcean Spaces", map[string]interface{}{
+// DeleteExportObject deletes an export artifact under exports/<resumeId>/<fileName>.
+// This is a best-effort helper that can be used to clean up partial exports.
+func (sc *SpacesClient) DeleteExportObject(resumeID string, fileName string) error {
+	if resumeID == "" {
+		return fmt.Errorf("resumeID is required")
+	}
+	if strings.TrimSpace(fileName) == "" {
+		return fmt.Errorf("fileName is required")
+	}
+
+	safeFileName := filepath.Base(strings.TrimSpace(fileName))
+	objectKey := fmt.Sprintf("exports/%s/%s", resumeID, safeFileName)
+
+	sc.logger.Info("Deleting export object from DigitalOcean Spaces", map[string]interface{}{
 		"resume_id":  resumeID,
 		"object_key": objectKey,
-		"size_bytes": len(pdfData),
 	})
 
-	_, err := sc.client.PutObject(&s3.PutObjectInput{
-		Bucket:      aws.String(sc.bucketName),
-		Key:         aws.String(objectKey),
-		Body:        bytes.NewReader(pdfData),
-		ContentType: aws.String("application/pdf"),
-		ACL:         aws.String("public-read"),
+	_, err := sc.client.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(sc.bucketName),
+		Key:    aws.String(objectKey),
 	})
 	if err != nil {
-		sc.logger.Error("Failed to upload PDF export to DigitalOcean Spaces", map[string]interface{}{
+		sc.logger.Warn("Failed to delete export object from DigitalOcean Spaces", map[string]interface{}{
 			"resume_id":  resumeID,
 			"object_key": objectKey,
 			"error":      err.Error(),
 		})
-		return "", fmt.Errorf("failed to upload PDF export: %w", err)
+		return fmt.Errorf("failed to delete export object: %w", err)
 	}
 
-	var fileURL string
-	if sc.cdnURL != "" {
-		fileURL = fmt.Sprintf("%s/%s", strings.TrimRight(sc.cdnURL, "/"), objectKey)
-	} else if sc.bucketURL != "" {
-		bucketBaseURL := strings.TrimRight(sc.bucketURL, "/")
-		if !strings.HasPrefix(bucketBaseURL, "https://") {
-			bucketBaseURL = "https://" + bucketBaseURL
-		}
-		fileURL = fmt.Sprintf("%s/%s", bucketBaseURL, objectKey)
-	} else {
-		region := ""
-		if sc.client.Config.Region != nil {
-			region = *sc.client.Config.Region
-		}
-		fileURL = fmt.Sprintf("https://%s.%s.digitaloceanspaces.com/%s", sc.bucketName, region, objectKey)
-	}
-
-	sc.logger.Info("PDF export uploaded successfully", map[string]interface{}{
+	sc.logger.Info("Export object deleted successfully", map[string]interface{}{
 		"resume_id":  resumeID,
 		"object_key": objectKey,
-		"url":        fileURL,
 	})
 
-	return fileURL, nil
+	return nil
 }


### PR DESCRIPTION
### Issue:
[LTB-93 | core: Generate PDF documents from intermediate .tex files for resumes](https://linear.app/letraz/issue/LTB-93/core-generate-pdf-documents-from-intermediate-tex-files-for-resumes)

### Description:
Implement the functionality in `letraz-utils` to compile intermediate `.tex` files into high-quality PDF resumes for user downloads.

### Changes Made:
- Integrated a LaTeX compiler (`pdflatex`) into the `letraz-utils` Docker image.
- Implemented `CompileLatexToPdf` Go function to compile LaTeX content to PDF, handling temporary file cleanup.
- Added robust error handling for compilation issues and integrated the function into the resume generation flow.
- Considered Docker image size by selecting appropriate TeX Live variant and addressed security concerns for running external processes.

### Closing Note:
This PR enhances the resume generation process by enabling the conversion of LaTeX resumes to professional PDF documents, improving user experience and document quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export responses now return separate LaTeX and PDF URLs; exports produce both artifacts.
  * Optional external PDF-rendering service supported with health-checked integration; local compilation fallback included.
  * Upload and deletion APIs for PDF exports added; improved per-step error reporting.

* **Chores**
  * Deployment and tooling updated to manage a dedicated renderer service, network, image targets, and rollout/rollback with health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->