### PR TITLE
LTB-107 | bug: Some fields are not being parsed while exporting resumes due to field names casing issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   letraz-utils:
-    image: letraz-utils:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: letraz-utils
     depends_on:
       - pdf-renderer

--- a/internal/latex/engine.go
+++ b/internal/latex/engine.go
@@ -2,6 +2,7 @@ package latex
 
 import (
 	"bytes"
+	"embed"
 	"fmt"
 	"regexp"
 	"strings"
@@ -9,6 +10,9 @@ import (
 
 	"letraz-utils/pkg/models"
 )
+
+//go:embed themes/*.tex
+var themesFS embed.FS
 
 // Engine renders resume data into LaTeX using named themes
 type Engine struct {
@@ -50,7 +54,12 @@ const DefaultTheme = "DEFAULT_THEME"
 func getThemeTemplate(theme string) (string, error) {
 	switch strings.ToUpper(strings.TrimSpace(theme)) {
 	case "", DefaultTheme:
-		return defaultThemeTemplate, nil
+		// Load default theme from embedded filesystem
+		content, err := themesFS.ReadFile("themes/default.tex")
+		if err != nil {
+			return "", fmt.Errorf("failed to load default theme: %w", err)
+		}
+		return string(content), nil
 	default:
 		return "", fmt.Errorf("unknown theme: %s", theme)
 	}
@@ -93,8 +102,8 @@ type CertificationVM struct {
 }
 
 type SkillsVM struct {
-	Languages    []string
-	Technologies []string
+	Categories    map[string][]string // Map of category name to skills
+	Uncategorized []string            // Skills without category
 }
 
 type SectionItemVM struct {
@@ -137,8 +146,8 @@ func buildViewModel(resume models.BaseResume) ViewModel {
 		case "skill":
 			// Per-section skills
 			if m, ok := s.Data.(map[string]interface{}); ok {
-				var languages []string
-				var technologies []string
+				categories := make(map[string][]string)
+				var uncategorized []string
 				if arr, ok := m["skills"].([]interface{}); ok {
 					for _, it := range arr {
 						if item, ok := it.(map[string]interface{}); ok {
@@ -148,17 +157,25 @@ func buildViewModel(resume models.BaseResume) ViewModel {
 								if name == "" {
 									continue
 								}
-								if strings.EqualFold(category, "Programming Languages") {
-									languages = append(languages, name)
-								} else if category != "" {
-									technologies = append(technologies, name)
+								// Group skills by category
+								if category == "" || category == "null" {
+									uncategorized = append(uncategorized, name)
+								} else {
+									if categories[category] == nil {
+										categories[category] = []string{}
+									}
+									categories[category] = append(categories[category], name)
 								}
 							}
 						}
 					}
 				}
+				// Remove duplicates from each category
+				for cat, skills := range categories {
+					categories[cat] = uniqueNonEmpty(skills)
+				}
 				kind := "Skills"
-				vm.Sections = append(vm.Sections, SectionItemVM{Kind: kind, Skills: &SkillsVM{Languages: uniqueNonEmpty(languages), Technologies: uniqueNonEmpty(technologies)}, ShowHeader: kind != prevKind})
+				vm.Sections = append(vm.Sections, SectionItemVM{Kind: kind, Skills: &SkillsVM{Categories: categories, Uncategorized: uniqueNonEmpty(uncategorized)}, ShowHeader: kind != prevKind})
 				prevKind = kind
 			}
 		case "education":
@@ -428,158 +445,3 @@ func formatPeriod(sm *int, sy *int, fm *int, fy *int) string {
 	}
 	return fmt.Sprintf("%s – %s", left, right)
 }
-
-// ===== DEFAULT THEME TEMPLATE =====
-
-// Note: Closely follows sample_latex.tex, with template placeholders
-const defaultThemeTemplate = `\documentclass[10pt, letterpaper]{article}
-
-% Packages:
-\usepackage[
-    ignoreheadfoot,
-    top=2 cm,
-    bottom=2 cm,
-    left=2 cm,
-    right=2 cm,
-    footskip=1.0 cm,
-]{geometry}
-\usepackage{titlesec}
-\usepackage{tabularx}
-\usepackage{array}
-\usepackage[dvipsnames]{xcolor}
-\definecolor{primaryColor}{RGB}{0, 0, 0}
-\usepackage{enumitem}
-\usepackage{fontawesome5}
-\usepackage{amsmath}
-\usepackage[
-    pdftitle={{ printf "{%s's CV}" (escape .Name) }},
-    pdfauthor={{ printf "{%s}" (escape .Name) }},
-    pdfcreator={Letraz Utils},
-    colorlinks=true,
-    urlcolor=primaryColor
-]{hyperref}
-\usepackage[pscoord]{eso-pic}
-\usepackage{calc}
-\usepackage{bookmark}
-\usepackage{lastpage}
-\usepackage{changepage}
-\usepackage{paracol}
-\usepackage{ifthen}
-\usepackage{needspace}
-\usepackage{iftex}
-
-\ifPDFTeX
-    \pdfgentounicode=1
-    \usepackage[T1]{fontenc}
-    \usepackage[utf8]{inputenc}
-    \usepackage{lmodern}
-\fi
-
-\usepackage{charter}
-
-% Settings
-\raggedright
-\AtBeginEnvironment{adjustwidth}{\partopsep0pt}
-\pagestyle{empty}
-\setcounter{secnumdepth}{0}
-\setlength{\parindent}{0pt}
-\setlength{\topskip}{0pt}
-\setlength{\columnsep}{0.15cm}
-\pagenumbering{gobble}
-
-\titleformat{\section}{\needspace{4\baselineskip}\bfseries\large}{}{0pt}{}[\vspace{1pt}\titlerule]
-\titlespacing{\section}{-1pt}{0.3 cm}{0.2 cm}
-
-\renewcommand\labelitemi{$\vcenter{\hbox{\small$\bullet$}}$}
-\newenvironment{highlights}{\begin{itemize}[topsep=0.10 cm,parsep=0.10 cm,partopsep=0pt,itemsep=0pt,leftmargin=0 cm + 10pt]}{\end{itemize}}
-\newenvironment{highlightsforbulletentries}{\begin{itemize}[topsep=0.10 cm,parsep=0.10 cm,partopsep=0pt,itemsep=0pt,leftmargin=10pt]}{\end{itemize}}
-\newenvironment{onecolentry}{\begin{adjustwidth}{0 cm + 0.00001 cm}{0 cm + 0.00001 cm}}{\end{adjustwidth}}
-\newenvironment{twocolentry}[2][]{\onecolentry\def\secondColumn{#2}\setcolumnwidth{\fill, 4.5 cm}\begin{paracol}{2}}{\switchcolumn \raggedleft \secondColumn\end{paracol}\endonecolentry}
-\newenvironment{threecolentry}[3][]{\onecolentry\def\thirdColumn{#3}\setcolumnwidth{, \fill, 4.5 cm}\begin{paracol}{3}{\raggedright #2} \switchcolumn}{\switchcolumn \raggedleft \thirdColumn\end{paracol}\endonecolentry}
-\newenvironment{header}{\setlength{\topsep}{0pt}\par\kern\topsep\centering\linespread{1.5}}{\par\kern\topsep}
-
-\begin{document}
-    \newcommand{\AND}{\unskip\cleaders\copy\ANDbox\hskip\wd\ANDbox\ignorespaces}
-    \newsavebox\ANDbox\sbox\ANDbox{$|$}
-
-    \begin{header}
-        \fontsize{25 pt}{25 pt}\selectfont {{ escape .Name }}
-
-        \vspace{5 pt}
-
-        \normalsize
-        {{- if .Address }}\mbox{\faGlobe}\ {{ escape .Address }}{{ end }}
-        {{- if .Email }}\kern 5.0 pt\mbox{\faEnvelope}\ {\href{mailto:{{ .Email }}}{ {{ escape .Email }} }}{{ end }}
-        {{- if .Phone }}\kern 5.0 pt\mbox{\faPhone}\ {\href{tel:{{ .Phone }}}{ {{ escape .Phone }} }}{{ end }}
-        {{- if .LinkedIn }}\kern 5.0 pt\mbox{\faLinkedin}\ {\href{ {{ .LinkedIn }} }{LinkedIn}}{{ end }}
-        {{- if .Github }}\kern 5.0 pt\mbox{\faGithub}\ {\href{ {{ .Github }} }{GitHub}}{{ end }}
-        {{- if .Website }}\kern 5.0 pt\mbox{\faGlobe}\ {\href{ {{ .Website }} }{ {{ escape .Website }} }}{{ end }}
-    \end{header}
-
-    \vspace{5 pt - 0.3 cm}
-
-    \section{Profile}
-        \begin{onecolentry}
-            {{ escape .Profile }}
-        \end{onecolentry}
-
-    {{- range .Sections }}
-        {{- if eq .Kind "Education" }}
-            {{- if .ShowHeader }}\section{Education}{{ end }}
-            \begin{twocolentry}{
-                {{ escape .Education.Period }}
-            }
-                \textbf{ {{- escape .Education.Institution -}} }, {{- escape .Education.Degree -}}\end{twocolentry}
-            \vspace{0.10 cm}
-            {{- if .Education.Highlights }}\begin{onecolentry}\begin{highlights}{{ range .Education.Highlights }}\item {{ escape . }}{{ end }}\end{highlights}\end{onecolentry}{{ end }}
-        {{- end }}
-
-        {{- if eq .Kind "Experience" }}
-            {{- if .ShowHeader }}\section{Experience}{{ end }}
-            \begin{twocolentry}{
-                {{ escape .Experience.Period }}
-            }
-                \textbf{ {{- escape .Experience.Title -}} }, {{- escape .Experience.Company -}} -- {{- escape .Experience.City -}}\end{twocolentry}
-            \vspace{0.10 cm}
-            {{- if .Experience.Highlights }}\begin{onecolentry}\begin{highlights}{{ range .Experience.Highlights }}\item {{ escape . }}{{ end }}\end{highlights}\end{onecolentry}{{ end }}
-            \vspace{0.2 cm}
-        {{- end }}
-
-        {{- if eq .Kind "Skills" }}
-            {{- if .ShowHeader }}\section{Skills}{{ end }}
-            {{- if .Skills.Languages }}\begin{onecolentry}\textbf{Languages:} {{ escJoin .Skills.Languages ", " }}\end{onecolentry}{{ end }}
-            {{- if .Skills.Technologies }}\vspace{0.2 cm}\begin{onecolentry}\textbf{Technologies:} {{ escJoin .Skills.Technologies ", " }}\end{onecolentry}{{ end }}
-        {{- end }}
-
-        {{- if eq .Kind "Projects" }}
-            {{- if .ShowHeader }}\section{Projects}{{ end }}
-            \begin{twocolentry}{
-                {{ escape .Project.Period }}
-            }
-                \textbf{ {{- escape .Project.Name -}} } -- \textit{ {{- escape .Project.Category -}} }\end{twocolentry}
-            \vspace{0.10 cm}
-            \begin{onecolentry}
-                {{- if .Project.Role }}{{ escape .Project.Role }}{{ end }}
-                {{- if or .Project.Github .Project.Live }} $|$ {{ end }}
-                {{- if .Project.Github }}\href{ {{ .Project.Github }} }{\faGithub\ GitHub}{{ end }}
-                {{- if and .Project.Github .Project.Live }} $|$ {{ end }}
-                {{- if .Project.Live }}\href{ {{ .Project.Live }} }{Live Demo}{{ end }}
-            \end{onecolentry}
-            {{- if .Project.Skills }}\vspace{0.10 cm}\begin{onecolentry}\textbf{Skills used:} {{ escJoin .Project.Skills ", " }}\end{onecolentry}{{ end }}
-            {{- if .Project.Highlights }}\vspace{0.10 cm}\begin{onecolentry}\begin{highlights}{{ range .Project.Highlights }}\item {{ escape . }}{{ end }}\end{highlights}\end{onecolentry}{{ end }}
-            \vspace{0.2 cm}
-        {{- end }}
-
-        {{- if eq .Kind "Certifications" }}
-            {{- if .ShowHeader }}\section{Certifications}{{ end }}
-            \begin{twocolentry}{
-                {{ escape .Certification.Period }}
-            }
-                \textbf{ {{- escape .Certification.Name -}} }\end{twocolentry}
-            {{- if or .Certification.Issuer .Certification.URL }}\vspace{0.10 cm}\begin{onecolentry}{{ if .Certification.Issuer }}{{ escape .Certification.Issuer }}{{ end }} {{ if and .Certification.Issuer .Certification.URL }} $|$ {{ end }} {{ if .Certification.URL }}\href{ {{ .Certification.URL }} }{View Certificate}{{ end }}\end{onecolentry}{{ end }}
-            \vspace{0.2 cm}
-        {{- end }}
-    {{- end }}
-
-\end{document}
-`

--- a/internal/latex/themes/README.md
+++ b/internal/latex/themes/README.md
@@ -1,0 +1,42 @@
+# LaTeX Resume Themes
+
+This directory contains LaTeX template files for different resume themes.
+
+## Available Themes
+
+- **default.tex**: The default resume theme with a clean, professional layout
+
+## Adding New Themes
+
+To add a new theme:
+
+1. Create a new `.tex` file in this directory (e.g., `modern.tex`, `elegant.tex`)
+2. Write your LaTeX template using Go template syntax for variable substitution
+3. Update the `getThemeTemplate` function in `engine.go` to handle your new theme name
+4. Use the same template variables as the default theme:
+   - `.Name`, `.Address`, `.Email`, `.Phone`, `.Website`, `.Profile`
+   - `.Sections` array with `.Kind`, `.Education`, `.Experience`, `.Skills`, `.Project`, `.Certification`
+
+## Template Variables
+
+The template system provides these helper functions:
+- `escape`: Escapes LaTeX special characters
+- `escJoin`: Escapes and joins an array of strings with a separator
+- `printf`: Standard Go template printf function
+
+## Example Usage
+
+```latex
+\section{Profile}
+    \begin{onecolentry}
+        {{ escape .Profile }}
+    \end{onecolentry}
+
+{{- range .Sections }}
+    {{- if eq .Kind "Skills" }}
+        {{- range $category, $skills := .Skills.Categories }}
+            \textbf{ {{- escape $category -}} :} {{ escJoin $skills ", " }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+```

--- a/internal/latex/themes/default.tex
+++ b/internal/latex/themes/default.tex
@@ -1,0 +1,155 @@
+\documentclass[10pt, letterpaper]{article}
+
+% Packages:
+\usepackage[
+    ignoreheadfoot,
+    top=2 cm,
+    bottom=2 cm,
+    left=2 cm,
+    right=2 cm,
+    footskip=1.0 cm,
+]{geometry}
+\usepackage{titlesec}
+\usepackage{tabularx}
+\usepackage{array}
+\usepackage[dvipsnames]{xcolor}
+\definecolor{primaryColor}{RGB}{0, 0, 0}
+\usepackage{enumitem}
+\usepackage{fontawesome5}
+\usepackage{amsmath}
+\usepackage[
+    pdftitle={{ printf "{%s's CV}" (escape .Name) }},
+    pdfauthor={{ printf "{%s}" (escape .Name) }},
+    pdfcreator={Letraz Utils},
+    colorlinks=true,
+    urlcolor=primaryColor
+]{hyperref}
+\usepackage[pscoord]{eso-pic}
+\usepackage{calc}
+\usepackage{bookmark}
+\usepackage{lastpage}
+\usepackage{changepage}
+\usepackage{paracol}
+\usepackage{ifthen}
+\usepackage{needspace}
+\usepackage{iftex}
+
+\ifPDFTeX
+    \pdfgentounicode=1
+    \usepackage[T1]{fontenc}
+    \usepackage[utf8]{inputenc}
+    \usepackage{lmodern}
+\fi
+
+\usepackage{charter}
+
+% Settings
+\raggedright
+\AtBeginEnvironment{adjustwidth}{\partopsep0pt}
+\pagestyle{empty}
+\setcounter{secnumdepth}{0}
+\setlength{\parindent}{0pt}
+\setlength{\topskip}{0pt}
+\setlength{\columnsep}{0.15cm}
+\pagenumbering{gobble}
+
+\titleformat{\section}{\needspace{4\baselineskip}\bfseries\large}{}{0pt}{}[\vspace{1pt}\titlerule]
+\titlespacing{\section}{-1pt}{0.3 cm}{0.2 cm}
+
+\renewcommand\labelitemi{$\vcenter{\hbox{\small$\bullet$}}$}
+\newenvironment{highlights}{\begin{itemize}[topsep=0.10 cm,parsep=0.10 cm,partopsep=0pt,itemsep=0pt,leftmargin=0 cm + 10pt]}{\end{itemize}}
+\newenvironment{highlightsforbulletentries}{\begin{itemize}[topsep=0.10 cm,parsep=0.10 cm,partopsep=0pt,itemsep=0pt,leftmargin=10pt]}{\end{itemize}}
+\newenvironment{onecolentry}{\begin{adjustwidth}{0 cm + 0.00001 cm}{0 cm + 0.00001 cm}}{\end{adjustwidth}}
+\newenvironment{twocolentry}[2][]{\onecolentry\def\secondColumn{#2}\setcolumnwidth{\fill, 4.5 cm}\begin{paracol}{2}}{\switchcolumn \raggedleft \secondColumn\end{paracol}\endonecolentry}
+\newenvironment{threecolentry}[3][]{\onecolentry\def\thirdColumn{#3}\setcolumnwidth{, \fill, 4.5 cm}\begin{paracol}{3}{\raggedright #2} \switchcolumn}{\switchcolumn \raggedleft \thirdColumn\end{paracol}\endonecolentry}
+\newenvironment{header}{\setlength{\topsep}{0pt}\par\kern\topsep\centering\linespread{1.5}}{\par\kern\topsep}
+
+\begin{document}
+    \newcommand{\AND}{\unskip\cleaders\copy\ANDbox\hskip\wd\ANDbox\ignorespaces}
+    \newsavebox\ANDbox\sbox\ANDbox{$|$}
+
+    \begin{header}
+        \fontsize{25 pt}{25 pt}\selectfont {{ escape .Name }}
+
+        \vspace{5 pt}
+
+        \normalsize
+        {{- if .Address }}\mbox{\faGlobe}\ {{ escape .Address }}{{ end }}
+        {{- if .Email }}\kern 5.0 pt\mbox{\faEnvelope}\ {\href{mailto:{{ .Email }}}{ {{ escape .Email }} }}{{ end }}
+        {{- if .Phone }}\kern 5.0 pt\mbox{\faPhone}\ {\href{tel:{{ .Phone }}}{ {{ escape .Phone }} }}{{ end }}
+        {{- if .LinkedIn }}\kern 5.0 pt\mbox{\faLinkedin}\ {\href{ {{ .LinkedIn }} }{LinkedIn}}{{ end }}
+        {{- if .Github }}\kern 5.0 pt\mbox{\faGithub}\ {\href{ {{ .Github }} }{GitHub}}{{ end }}
+        {{- if .Website }}\kern 5.0 pt\mbox{\faGlobe}\ {\href{ {{ .Website }} }{ {{ escape .Website }} }}{{ end }}
+    \end{header}
+
+    \vspace{5 pt - 0.3 cm}
+
+    \section{Profile}
+        \begin{onecolentry}
+            {{ escape .Profile }}
+        \end{onecolentry}
+
+    {{- range .Sections }}
+        {{- if eq .Kind "Education" }}
+            {{- if .ShowHeader }}\section{Education}{{ end }}
+            \begin{twocolentry}{
+                {{ escape .Education.Period }}
+            }
+                \textbf{ {{- escape .Education.Institution -}} }, {{- escape .Education.Degree -}}\end{twocolentry}
+            \vspace{0.10 cm}
+            {{- if .Education.Highlights }}\begin{onecolentry}\begin{highlights}{{ range .Education.Highlights }}\item {{ escape . }}{{ end }}\end{highlights}\end{onecolentry}{{ end }}
+        {{- end }}
+
+        {{- if eq .Kind "Experience" }}
+            {{- if .ShowHeader }}\section{Experience}{{ end }}
+            \begin{twocolentry}{
+                {{ escape .Experience.Period }}
+            }
+                \textbf{ {{- escape .Experience.Title -}} }, {{- escape .Experience.Company -}} -- {{- escape .Experience.City -}}\end{twocolentry}
+            \vspace{0.10 cm}
+            {{- if .Experience.Highlights }}\begin{onecolentry}\begin{highlights}{{ range .Experience.Highlights }}\item {{ escape . }}{{ end }}\end{highlights}\end{onecolentry}{{ end }}
+            \vspace{0.2 cm}
+        {{- end }}
+
+        {{- if eq .Kind "Skills" }}
+            {{- if .ShowHeader }}\section{Skills}{{ end }}
+            {{- range $category, $skills := .Skills.Categories }}
+                \begin{onecolentry}\textbf{ {{- escape $category -}} :} {{ escJoin $skills ", " }}\end{onecolentry}
+                \vspace{0.2 cm}
+            {{- end }}
+            {{- if .Skills.Uncategorized }}
+                \begin{onecolentry}{{ escJoin .Skills.Uncategorized ", " }}\end{onecolentry}
+            {{- end }}
+        {{- end }}
+
+        {{- if eq .Kind "Projects" }}
+            {{- if .ShowHeader }}\section{Projects}{{ end }}
+            \begin{twocolentry}{
+                {{ escape .Project.Period }}
+            }
+                \textbf{ {{- escape .Project.Name -}} } -- \textit{ {{- escape .Project.Category -}} }\end{twocolentry}
+            \vspace{0.10 cm}
+            \begin{onecolentry}
+                {{- if .Project.Role }}{{ escape .Project.Role }}{{ end }}
+                {{- if or .Project.Github .Project.Live }} $|$ {{ end }}
+                {{- if .Project.Github }}\href{ {{ .Project.Github }} }{\faGithub\ GitHub}{{ end }}
+                {{- if and .Project.Github .Project.Live }} $|$ {{ end }}
+                {{- if .Project.Live }}\href{ {{ .Project.Live }} }{Live Demo}{{ end }}
+            \end{onecolentry}
+            {{- if .Project.Skills }}\vspace{0.10 cm}\begin{onecolentry}\textbf{Skills used:} {{ escJoin .Project.Skills ", " }}\end{onecolentry}{{ end }}
+            {{- if .Project.Highlights }}\vspace{0.10 cm}\begin{onecolentry}\begin{highlights}{{ range .Project.Highlights }}\item {{ escape . }}{{ end }}\end{highlights}\end{onecolentry}{{ end }}
+            \vspace{0.2 cm}
+        {{- end }}
+
+        {{- if eq .Kind "Certifications" }}
+            {{- if .ShowHeader }}\section{Certifications}{{ end }}
+            \begin{twocolentry}{
+                {{ escape .Certification.Period }}
+            }
+                \textbf{ {{- escape .Certification.Name -}} }\end{twocolentry}
+            {{- if or .Certification.Issuer .Certification.URL }}\vspace{0.10 cm}\begin{onecolentry}{{ if .Certification.Issuer }}{{ escape .Certification.Issuer }}{{ end }} {{ if and .Certification.Issuer .Certification.URL }} $|$ {{ end }} {{ if .Certification.URL }}\href{ {{ .Certification.URL }} }{View Certificate}{{ end }}\end{onecolentry}{{ end }}
+            \vspace{0.2 cm}
+        {{- end }}
+    {{- end }}
+
+\end{document}


### PR DESCRIPTION
### Issue:
[LTB-107 | bug: Some fields are not being parsed while exporting resumes due to field names casing issue](https://linear.app/letraz/issue/LTB-107/bug-some-fields-are-not-being-parsed-while-exporting-resumes-due-to)

### Description:
Resolve the field name casing mismatch issue causing certain fields to be excluded during resume exports.

### Changes Made:
- Diagnosed and compared field names between `Resume` object and Go structs/templating engine.
- Standardized field naming conventions to ensure consistency.
- Refactored templating context to match expected field casing.
- Conducted comprehensive testing to validate correct field rendering in exported documents.
- Added debug logging for better visibility into data passed to the templating engine.

### Closing Note:
This PR addresses a critical bug impacting the completeness and accuracy of exported resumes by fixing the field name casing mismatch issue, ensuring all relevant fields are correctly parsed and included in the output documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New embedded LaTeX theme system with an enhanced default resume template.
  - Skills now grouped by categories with support for uncategorized items in generated PDFs.
  - Broader JSON compatibility: user data imports accept both snake_case and camelCase.

- Documentation
  - Added guide for creating and using LaTeX resume themes.

- Chores
  - Docker setup updated to build the utilities service locally via docker-compose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->