### PR TITLE
LTB-119 | impr: Skip Claude extraction for Firecrawl scrapping and extract structured data directly from Firecrawl

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -54,6 +54,7 @@ firecrawl:
   timeout: "60s"
   max_retries: 3
   formats: ["markdown"]  # Default formats: markdown, html, rawHtml, links, screenshot
+  use_extract: false  # Enable schema-based extraction (env: FIRECRAWL_USE_EXTRACT)
 
 brightdata:
   api_key: "${BRIGHTDATA_TOKEN}"  # Set via environment variable BRIGHTDATA_TOKEN

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -317,8 +317,10 @@ func (c *Config) loadFromEnv() {
 	}
 
 	// Enable Firecrawl extract flow via env flag
-	if useExtract := os.Getenv("FIRECRAWL_USE_EXTRACT"); useExtract != "" {
-		c.Firecrawl.UseExtract = useExtract == "true" || useExtract == "1"
+	if v := os.Getenv("FIRECRAWL_USE_EXTRACT"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			c.Firecrawl.UseExtract = b
+		}
 	}
 
 	if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ type Config struct {
 		Timeout    time.Duration `yaml:"timeout" default:"60s"`
 		MaxRetries int           `yaml:"max_retries" default:"3"`
 		Formats    []string      `yaml:"formats" default:"markdown"`
+		UseExtract bool          `yaml:"use_extract" default:"false"`
 	} `yaml:"firecrawl"`
 
 	BrightData struct {
@@ -213,6 +214,7 @@ func LoadConfig(configPath string) (*Config, error) {
 	config.Firecrawl.MaxRetries = 3
 	config.Firecrawl.Timeout = 60 * time.Second
 	config.Firecrawl.Formats = []string{"markdown"}
+	config.Firecrawl.UseExtract = false
 
 	config.Logging.Level = "warn"
 	config.Logging.Format = "json"
@@ -312,6 +314,11 @@ func (c *Config) loadFromEnv() {
 
 	if firecrawlVersion := os.Getenv("FIRECRAWL_VERSION"); firecrawlVersion != "" {
 		c.Firecrawl.Version = firecrawlVersion
+	}
+
+	// Enable Firecrawl extract flow via env flag
+	if useExtract := os.Getenv("FIRECRAWL_USE_EXTRACT"); useExtract != "" {
+		c.Firecrawl.UseExtract = useExtract == "true" || useExtract == "1"
 	}
 
 	if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {

--- a/internal/scraper/engines/firecrawl/firecrawl.go
+++ b/internal/scraper/engines/firecrawl/firecrawl.go
@@ -308,7 +308,10 @@ func (f *FirecrawlScraper) extractJobWithFirecrawl(ctx context.Context, url stri
 	}
 	defer resp.Body.Close()
 
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("failed to read extract response body: %w", readErr)
+	}
 
 	f.logger.Debug("Received Firecrawl response", map[string]interface{}{
 		"status_code":   resp.StatusCode,


### PR DESCRIPTION
### Issue:
[LTB-119 | impr: Skip Claude extraction for Firecrawl scrapping and extract structured data directly from Firecrawl](https://linear.app/letraz/issue/LTB-119/impr-skip-claude-extraction-for-firecrawl-scrapping-and-extract)

### Description:
This pull request aims to optimize the scraping workflow by bypassing the Claude extraction step when using Firecrawl and directly leveraging Firecrawl's capabilities to return structured data, enhancing efficiency and reducing dependencies.

### Changes Made:
- Updated `letraz-utils` Firecrawl client to request structured job data directly from Firecrawl.
- Implemented conditional logic in `ScrapeJob` gRPC method to skip Claude extraction if Firecrawl returns structured data.
- Enhanced data validation and mapping for structured data received from Firecrawl.
- Improved logging to track usage of Firecrawl's direct structured extraction and Claude fallback.
- Added integration tests to validate data extraction scenarios and ensure consistent `Job` object formation.

### Closing Note:
This PR is crucial for streamlining the scraping process, reducing costs, improving performance, and simplifying post-scraping processing in `letraz-utils`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional schema-based extraction step for Firecrawl that can return structured job data when available.
  * New config flag (use_extract) with env support (FIRECRAWL_USE_EXTRACT) to enable the extraction path.
* **Improvements**
  * More reliable extraction with validation and automatic fallback to standard scraping when extraction yields no usable result.
* **Bug Fixes**
  * Callback payloads now omit data on failures and include only meaningful job fields, reducing empty/irrelevant responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->